### PR TITLE
[ag] remove interlocks rewrite in nginx config

### DIFF
--- a/ls_dev.conf
+++ b/ls_dev.conf
@@ -34,11 +34,6 @@ server {
     location ~ ^/(org|person)/([0-9]+)/.+/giving {
       try_files $uri /app.php$is_args$args;
     }
-
-    location ~ ^/org/([0-9]+)/.+/interlocks {
-      try_files $uri /app.php$is_args$args;
-    }
-    
     
     location /entity {
         try_files $uri /app.php$is_args$args;


### PR DESCRIPTION
we may safely remove this rewrite rule, since [this PR](https://github.com/public-accountability/littlesis-rails/pull/349) in the rails app eliminates the need to delegate to symfony for org interlocks